### PR TITLE
Update README for changes to server.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ To install and run simply follow these steps:
 
 2)  Open your terminal and run `node server.js`
 
-3)  Your server is now available at `http://localhost:6060/`
+3)  Your server is now available at `http://localhost:6069/`
 
-4)  You can run a quick test by entering this in your browser: `http://localhost:6060/animals`
+4)  You can run a quick test by entering this in your browser: `http://localhost:6069/ingredients`
 
 5)  Build your test data right in the server.js file. Create new endpoints as needed


### PR DESCRIPTION
Unlike the version this Readme was written for, it seems like the current `server.js` code uses port 6069 rather than 6060 and has an "ingredients" endpoint rather than an "animals" endpoint.
